### PR TITLE
Bump react-auth package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1358,9 +1358,9 @@
       }
     },
     "@reshuffle/react-auth": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@reshuffle/react-auth/-/react-auth-0.1.4.tgz",
-      "integrity": "sha512-y/sFAS2mZaDYWTtpnv7r4aIiRaTJNbUmFp8TV8I1pmX8ei8g/Z0EjAXgw21mb/2h22bCoSIiMSpgU+B6AloyGw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@reshuffle/react-auth/-/react-auth-0.1.6.tgz",
+      "integrity": "sha512-LXNwWi+VCibIbEauCc8m+admfRW5ZJpjTbeLrXT85YCLBQnXfOKTcLHqrrkO7tLCs1Vn5cuBbflY8qgFzrDzjg==",
       "requires": {
         "@reshuffle/auth": "0.0.1",
         "react-async-hook": "^3.6.1"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reshuffle/fetch-runtime": "^0.1.0",
     "@reshuffle/local-proxy": "^0.3.1",
     "@reshuffle/passport": "^0.1.2",
-    "@reshuffle/react-auth": "^0.1.4",
+    "@reshuffle/react-auth": "^0.1.6",
     "@reshuffle/server-function": "^0.2.2",
     "eslint-config-react-app": "^5.0.2",
     "eslint-plugin-prettier": "^3.1.1",


### PR DESCRIPTION
This version prints much nicer error messages if you delete
`backend/_handler.js`.